### PR TITLE
reduce memory footprint for icmp ping handler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.72.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.25.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4")
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/HTTPChannelTests/HTTPTracingHandlerTests.swift
+++ b/Tests/HTTPChannelTests/HTTPTracingHandlerTests.swift
@@ -68,6 +68,7 @@ final class HTTPTracingHandlerTests: XCTestCase {
             XCTAssertEqual(request.method, HTTPMethod.GET)
             XCTAssertEqual(request.uri, config.url.uri)
             XCTAssertEqual(request.headers, config.httpHeaders)
+            promise.succeed(.ok(2, 0, 0))
         default:
             XCTFail("Should receive a head and end. But received head = \(String(describing: head)), end = \(String(describing: end))")
         }


### PR DESCRIPTION
Reduce memory footprint for ICMP Handler by switching to BitSet from swift-collections